### PR TITLE
Fix uncaught PHP 8.1 Incompatibility

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -22,4 +22,8 @@
             <directory suffix=".php">./src</directory>
         </include>
     </coverage>
+
+    <php>
+        <ini name="error_reporting" value="E_ALL" />
+    </php>
 </phpunit>

--- a/tests/Unit/Models/CaseInsensitiveArrayTest.php
+++ b/tests/Unit/Models/CaseInsensitiveArrayTest.php
@@ -19,6 +19,12 @@ class CaseInsensitiveArrayTest extends TestCase
         self::assertSame(1, $data['value']);
     }
 
+    public function testThatOffsetGetDoesNotIssueANoticeOnPHP81(): void
+    {
+        $data = new CaseInsensitiveArray(['hey' => 'there']);
+        self::assertEquals('there', $data->offsetGet('hey'));
+    }
+
     public function testValuesCanBeMutatedInACaseInsensitiveWay(): void
     {
         $data = new CaseInsensitiveArray(['value' => 1]);


### PR DESCRIPTION
Add failing test case for CaseInsensitiveArray on 8.1 and make sure that PHPUnit turns up the error level