### PR TITLE
Remove `@internal` annotations

### DIFF
--- a/src/Postmark/ClientBehaviour/Bounces.php
+++ b/src/Postmark/ClientBehaviour/Bounces.php
@@ -8,7 +8,6 @@ use Postmark\Models\DynamicResponseModel;
 
 use function sprintf;
 
-/** @internal \Postmark */
 trait Bounces
 {
     /**

--- a/src/Postmark/ClientBehaviour/InboundMessages.php
+++ b/src/Postmark/ClientBehaviour/InboundMessages.php
@@ -8,7 +8,6 @@ use Postmark\Models\DynamicResponseModel;
 
 use function sprintf;
 
-/** @internal \Postmark */
 trait InboundMessages
 {
     /**

--- a/src/Postmark/ClientBehaviour/MessageStreams.php
+++ b/src/Postmark/ClientBehaviour/MessageStreams.php
@@ -8,7 +8,6 @@ use Postmark\Models\DynamicResponseModel;
 
 use function sprintf;
 
-/** @internal \Postmark */
 trait MessageStreams
 {
     /**

--- a/src/Postmark/ClientBehaviour/OutboundMessages.php
+++ b/src/Postmark/ClientBehaviour/OutboundMessages.php
@@ -11,8 +11,6 @@ use function is_string;
 use function sprintf;
 
 /**
- * @internal \Postmark
- *
  * @see PostmarkClient
  *
  * @psalm-import-type MetaData from PostmarkClient

--- a/src/Postmark/ClientBehaviour/PostmarkClientBase.php
+++ b/src/Postmark/ClientBehaviour/PostmarkClientBase.php
@@ -33,7 +33,6 @@ use const PHP_OS_FAMILY;
 use const PHP_QUERY_RFC3986;
 use const PHP_RELEASE_VERSION;
 
-/** @internal Postmark */
 abstract class PostmarkClientBase
 {
     use Discovery;

--- a/src/Postmark/ClientBehaviour/Statistics.php
+++ b/src/Postmark/ClientBehaviour/Statistics.php
@@ -8,7 +8,6 @@ use Postmark\Models\DynamicResponseModel;
 
 use function sprintf;
 
-/** @internal \Postmark */
 trait Statistics
 {
     /**

--- a/src/Postmark/ClientBehaviour/Suppressions.php
+++ b/src/Postmark/ClientBehaviour/Suppressions.php
@@ -9,7 +9,6 @@ use Postmark\Models\Suppressions\SuppressionChangeRequest;
 
 use function sprintf;
 
-/** @internal \Postmark */
 trait Suppressions
 {
     /**

--- a/src/Postmark/ClientBehaviour/Templates.php
+++ b/src/Postmark/ClientBehaviour/Templates.php
@@ -10,8 +10,6 @@ use Postmark\PostmarkClient;
 use function sprintf;
 
 /**
- * @internal \Postmark
- *
  * @see PostmarkClient
  *
  * @psalm-import-type TemplateId from PostmarkClient

--- a/src/Postmark/ClientBehaviour/Webhooks.php
+++ b/src/Postmark/ClientBehaviour/Webhooks.php
@@ -13,8 +13,6 @@ use Postmark\PostmarkClient;
 use function sprintf;
 
 /**
- * @internal \Postmark
- *
  * @see PostmarkClient
  *
  * @psalm-import-type HeaderList from PostmarkClient

--- a/src/Postmark/Models/CaseInsensitiveArray.php
+++ b/src/Postmark/Models/CaseInsensitiveArray.php
@@ -20,8 +20,6 @@ use const CASE_LOWER;
  * CaseInsensitiveArray allows accessing elements with mixed-case keys.
  * This allows access to the array to be very forgiving. (i.e. If you access something
  * with the wrong CaSe, it'll still find the correct element)
- *
- * @internal Postmark
  */
 class CaseInsensitiveArray implements ArrayAccess, Iterator
 {


### PR DESCRIPTION
`@internal` marks all public methods as internal which causes unnecessary static analysis issues in user projects