### PR TITLE
Provide access to the server payload

### DIFF
--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,9 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.8.0@9cf4f60a333f779ad3bc704a555920e81d4fdcda">
-  <file src="src/Postmark/Models/CaseInsensitiveArray.php">
-    <MissingTemplateParam>
-      <code>ArrayAccess</code>
-      <code>Iterator</code>
-    </MissingTemplateParam>
-  </file>
-</files>
+<files psalm-version="5.20.0@3f284e96c9d9be6fe6b15c79416e1d1903dcfef4"/>

--- a/src/Postmark/Models/CaseInsensitiveArray.php
+++ b/src/Postmark/Models/CaseInsensitiveArray.php
@@ -20,12 +20,17 @@ use const CASE_LOWER;
  * CaseInsensitiveArray allows accessing elements with mixed-case keys.
  * This allows access to the array to be very forgiving. (i.e. If you access something
  * with the wrong CaSe, it'll still find the correct element)
+ *
+ * @implements ArrayAccess<array-key, mixed>
+ * @implements Iterator<array-key, mixed>
  */
 class CaseInsensitiveArray implements ArrayAccess, Iterator
 {
     /** @var array<array-key, mixed> */
     private array $data;
     private int $pointer = 0;
+    /** @var array<array-key, mixed> */
+    private array $payload;
 
     private function normaliseOffset(string $offset): string
     {
@@ -39,7 +44,18 @@ class CaseInsensitiveArray implements ArrayAccess, Iterator
      */
     public function __construct(array $initialArray = [])
     {
+        $this->payload = $initialArray;
         $this->data = array_change_key_case($initialArray, CASE_LOWER);
+    }
+
+    /**
+     * Provides a way of accessing the initial payload as returned by the server with key casing preserved
+     *
+     * @return array<array-key, mixed>
+     */
+    public function getPayload(): array
+    {
+        return $this->payload;
     }
 
     /** @param array-key|null $offset */

--- a/tests/Unit/Models/CaseInsensitiveArrayTest.php
+++ b/tests/Unit/Models/CaseInsensitiveArrayTest.php
@@ -61,4 +61,30 @@ class CaseInsensitiveArrayTest extends TestCase
         unset($data['fOo']);
         self::assertArrayNotHasKey('foo', $data);
     }
+
+    public function testThatTheInitialPayloadCanBeAccessed(): void
+    {
+        $payload = [
+            'Foo' => 'foo',
+            'bar' => 'bar',
+            'bAz' => 'baz',
+            'BING' => 'bing',
+        ];
+
+        $data = new CaseInsensitiveArray($payload);
+
+        self::assertSame($payload, $data->getPayload());
+    }
+
+    public function testThatTheInitialPayloadWillIncludeNestedArrays(): void
+    {
+        $payload = [
+            'SomeScalar' => 'foo',
+            'NestedArray' => ['OtherValue' => 'Bar'],
+        ];
+
+        $data = new CaseInsensitiveArray($payload);
+
+        self::assertSame($payload, $data->getPayload());
+    }
 }


### PR DESCRIPTION
Allows users to verify response structures as they appear in the documentation, without lowercased keys.