### PR TITLE
Allow header instances in message delivery methods

### DIFF
--- a/src/Postmark/Models/Header.php
+++ b/src/Postmark/Models/Header.php
@@ -6,15 +6,13 @@ namespace Postmark\Models;
 
 use JsonSerializable;
 
-use function assert;
-
 final class Header implements JsonSerializable
 {
     /**
      * @param non-empty-string $name
      * @param scalar|null      $value
      */
-    public function __construct(private string $name, private $value) // phpcs:ignore
+    public function __construct(private readonly string $name, private $value) // phpcs:ignore
     {
     }
 
@@ -28,7 +26,7 @@ final class Header implements JsonSerializable
     }
 
     /**
-     * @param array<string, scalar|null> $values
+     * @param array<string, scalar|null>|array<array-key, Header> $values
      *
      * @return list<self>|null
      */
@@ -40,7 +38,17 @@ final class Header implements JsonSerializable
 
         $list = [];
         foreach ($values as $name => $value) {
-            assert(! empty($name));
+            if ($value instanceof self) {
+                $list[] = $value;
+                continue;
+            }
+
+            $name = (string) $name;
+
+            if ($name === '') {
+                continue;
+            }
+
             $list[] = new self($name, $value);
         }
 

--- a/src/Postmark/PostmarkClient.php
+++ b/src/Postmark/PostmarkClient.php
@@ -26,7 +26,7 @@ use function strtolower;
  * @link JsonSerializable (Preserve Import)
  *
  * @psalm-type Attachments = list<PostmarkAttachment>|null
- * @psalm-type HeaderList = array<string, scalar|null>
+ * @psalm-type HeaderList = array<string, scalar|null>|array<array-key, Header>
  * @psalm-type MetaData = array<string, scalar>
  * @psalm-type TemplateId = non-empty-string|positive-int
  * @psalm-type EmailMessage = array{

--- a/tests/Unit/Models/HeaderTest.php
+++ b/tests/Unit/Models/HeaderTest.php
@@ -46,4 +46,41 @@ class HeaderTest extends TestCase
     {
         self::assertNull(Header::listFromArray([]));
     }
+
+    public function testThatHeaderInstancesCanBeUsed(): void
+    {
+        $input = [
+            'whatever' => new Header('X-Some-Header', 'Foo'),
+            'X-Other-Header' => 'Bar',
+        ];
+
+        $expect = json_encode([
+            ['Name' => 'X-Some-Header', 'Value' => 'Foo'],
+            ['Name' => 'X-Other-Header', 'Value' => 'Bar'],
+        ], JSON_THROW_ON_ERROR);
+
+        $headers = Header::listFromArray($input);
+
+        self::assertJsonStringEqualsJsonString($expect, json_encode($headers, JSON_THROW_ON_ERROR));
+    }
+
+    public function testThatEmptyKeysAreIgnored(): void
+    {
+        $input = [
+            0 => 'Some Value',
+            1 => 'Another Value',
+            '' => 'Not There',
+            'foo' => 'bar',
+        ];
+
+        $expect = json_encode([
+            ['Name' => '0', 'Value' => 'Some Value'],
+            ['Name' => '1', 'Value' => 'Another Value'],
+            ['Name' => 'foo', 'Value' => 'bar'],
+        ], JSON_THROW_ON_ERROR);
+
+        $headers = Header::listFromArray($input);
+
+        self::assertJsonStringEqualsJsonString($expect, json_encode($headers, JSON_THROW_ON_ERROR));
+    }
 }


### PR DESCRIPTION
If you had multiple headers with the same name and different values, it was impossible to provide them as a one dimensional hash.

This patch changes `Header::listFromArray()` so that it will accept instances of `Header` rather than assuming the argument is a map. The side effect is that users can supply a list of `Header` instances, thereby enabling multiple headers with the same name.

Additionally, this patch rejects array members with an empty string. Previously, an assertion error would have been thrown in dev, but silently and erroneously passed to the server in prod.